### PR TITLE
prepared for printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Open source, online coloring book through which one can explore the mathematics 
 http://coloring-book.co
 
 
+## Export to Print/Save
+
+- Works best with Firefox browser
+- Select to show no headers and only center page number as footer
+- "Preview as PDF"
+
+
 ## Development
 
 - Clone the repo `$ git clone git@github.com:aberke/coloring-book.git`

--- a/src/app/book/book.html
+++ b/src/app/book/book.html
@@ -4,7 +4,6 @@
     <!-- uses autoscroll to always start here -->
     <ng-include autoscroll src="'/app/book/pages/book-page-cover.html'"></ng-include>
 
-
     <!-- Shapes & Symmetries Section -->
     <section class="book-section" id="book-shapes">
 
@@ -12,19 +11,24 @@
 
         <!-- subtitle + triangles -->
         <ng-include src="'/app/book/pages/book-page-shapes-cn-1.html'"></ng-include>
+
         <!-- More rotations w/ Bad rotations dont line up -->
         <ng-include src="'/app/book/pages/book-page-shapes-cn-2.html'"></ng-include>
+
         <!-- Introduce C3 -->
         <ng-include src="'/app/book/pages/book-page-shapes-cn-3.html'"></ng-include>
+
         <!-- Back to C2, C3, C4, precisely compare -->
         <ng-include src="'/app/book/pages/book-page-shapes-cn-4.html'"></ng-include>
+
         <!-- More CN shapes -->
         <ng-include src="'/app/book/pages/book-page-shapes-cn-5.html'"></ng-include>
+
         <!-- define rotational order -->
         <ng-include src="'/app/book/pages/book-page-shapes-cn-6.html'"></ng-include>
+
         <!-- define CN groups -->
         <ng-include src="'/app/book/pages/book-page-shapes-cn-7.html'"></ng-include>
-
 
     </section>
 

--- a/src/app/book/pages/book-page-cover.html
+++ b/src/app/book/pages/book-page-cover.html
@@ -1,4 +1,4 @@
-<div class="book-section" id="book-cover">
+<div class="book-section book-page" id="book-cover">
 
     <!-- TODO: Replace with better name -->
     <div id="book-title-container">

--- a/src/app/book/pages/book-page-shapes-cn-1.html
+++ b/src/app/book/pages/book-page-shapes-cn-1.html
@@ -21,9 +21,6 @@
             <br/>
             <br/>
             <br/>
-            <br/>
-            <br/>
-
 
             <p>If the triangle were instead rotated by an arbitrary amount, like &frac14; of the way around a circle, it would then appear changed, since it is oriented differently.</p>
             <div class="text-content-graphic line">
@@ -47,10 +44,14 @@
                     options='{"text":"3/4 turn","autoRotateDegrees":120,"inscribed":true,"initialRotation":270}'
                 ></div>
             </div>
+
+            <br/>
+            <br/>
+
         </div>
 
         <!-- coloring-content -->
-        <div class="coloring-content">
+        <div class="coloring-content page-print-break-before">
             <!-- 3 Sierpinski triangles in a row -->
             <div class='canvas third'
                 canvas-centered-drawing

--- a/src/app/book/pages/book-page-shapes-cn-2.html
+++ b/src/app/book/pages/book-page-shapes-cn-2.html
@@ -1,6 +1,9 @@
 <div class="book-page">
     <div class="text-coloring-content-container">
 
+        <br/>
+        <br/>
+
         <div class="text-content">
             <p>We can still rotate that triangle more than &frac13; of the way around a circle without changing it.  It can be rotated by twice that much - &frac23; of the way around the circle - or by 3 times that much, which is all the way around the circle.</p>
             <div class="text-content-graphic line">
@@ -69,7 +72,9 @@
 
             <p>There are only 3 unique rotations for a triangle.  We'll talk about them by referring to the rotations that are less than a full turn.</p>
         </div>
-        <div class="coloring-content">
+
+        <!-- Page break for print -->
+        <div class="coloring-content page-print-break-before">
             <!-- 1 order=3 circular-tessellation -->
             <div
                 class="canvas" 

--- a/src/app/book/pages/book-page-shapes-cn-3.html
+++ b/src/app/book/pages/book-page-shapes-cn-3.html
@@ -1,5 +1,11 @@
 <div class="book-page">
 
+    <!-- Better for printing/exporting with space at top -->
+    <br/>
+    <br/>
+    <br/>
+    <br/>
+
     <div class="text-coloring-content-container">
         <div class="text-content">
             <p>Other shapes, not just equilateral triangles, have the same 3 rotations.  For this reason, we can say they're all in the same cyclic "group" (C3).</p>
@@ -43,7 +49,9 @@
                 ></div>
             </div>
         </div>
-        <div class="coloring-content">
+
+        <!-- Page break for print -->
+        <div class="coloring-content page-print-break-before">
         <!-- Line of Circular tessellations of rotational symmetry=3 -->
             <div class="canvas third"
                 circular-tessellation

--- a/src/app/book/pages/book-page-shapes-cn-4.html
+++ b/src/app/book/pages/book-page-shapes-cn-4.html
@@ -74,8 +74,9 @@
                 ></div>
             </div>
         </div>
-
-        <div class="coloring-content">
+        
+        <!-- Page break for print -->
+        <div class="coloring-content page-print-break-before">
             <!-- Line of circular tessellations of 2 rotations -->
             <div class="canvas third"
                 circular-tessellation

--- a/src/app/book/pages/book-page-shapes-cn-5.html
+++ b/src/app/book/pages/book-page-shapes-cn-5.html
@@ -40,7 +40,8 @@
             </div>
         </div>
 
-        <div class="coloring-content">
+        <!-- Page break for print -->
+        <div class="coloring-content page-print-break-before">
 
             <!-- Line of circular tessellations of 5 rotations -->
             <div class="canvas third"

--- a/src/app/book/pages/book-page-shapes-cn-6.html
+++ b/src/app/book/pages/book-page-shapes-cn-6.html
@@ -65,18 +65,7 @@
                     options='{"text":"Order 4", "autoRotateDegrees": 90}'
                 ></div>
             </div>
-        </div>
 
-        <div class="coloring-content">
-        [Use same lines to create circular tessellation of increasing order]
-        </div>
-    </div>
-
-
-
-
-    <div class="text-coloring-content-container">
-        <div class="text-content">
             <p>We can say the same for shapes that are not regular polygons.
             </p>
             <div class="text-content-graphic line">
@@ -101,9 +90,18 @@
                 ></div>
             </div>
         </div>
-
-        <div class="coloring-content">
-        [TODO]
+        
+        <!-- Page break for print -->
+        <div class="coloring-content page-print-break-before">
+            <div
+                class="canvas" 
+                with-redraw 
+                circular-tessellation
+                rotations=8
+                slices-count=4
+                levels=2
+                margin=20>
+            </div>
         </div>
     </div>
 </div>

--- a/src/app/book/pages/book-page-shapes-cn-7.html
+++ b/src/app/book/pages/book-page-shapes-cn-7.html
@@ -85,10 +85,10 @@
                     options='{"autoRotateDegrees":45}'
                 ></div>
             </div>
-
         </div>
 
-        <div class="coloring-content">
+        <!-- Page break for print -->
+        <div class="coloring-content page-print-break-before">
             <!-- Circular tessellations of rotational symmetry=3 -->
             <div
                 class="canvas third"
@@ -104,7 +104,7 @@
                 circular-tessellation
                 with-redraw
                 rotations=3
-                slices-count=5
+                slices-count=4
                 levels=2
                 margin=20>
             </div>

--- a/src/js/circular-tessellation.js
+++ b/src/js/circular-tessellation.js
@@ -47,6 +47,7 @@ class CircularTessellation {
 		this.levels = Number(this.options.levels) || 1;
 		this.scaleFactor = 2;
 		this.withReflection = this.options.withReflection ? Boolean(this.options.withReflection) : false;
+		
 		// slicesCount is the number of items in a line segment to be repeated
 		// make this number larger for more complicated patterns
 		this.slicesCount = this.options.slicesCount || 3;

--- a/src/js/paths.js
+++ b/src/js/paths.js
@@ -23,7 +23,7 @@ Path is randomly generated.
 */
 function getFundamentalDomainLineSlices(origin, width, height, slicesCount, withReflection) {
     slicesCount = slicesCount || 3;
-    withReflection = withReflection || true;
+    withReflection = withReflection || false;
 
     let pathList = [];
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -123,12 +123,45 @@ Structure
 	vertical-align: middle;
 }
 .text-content {
+	max-width: 600px;
 	width: 40%;
+	min-height: 200px;
+	vertical-align: middle;
 }
 .coloring-content {
 	width: 55%;
 	border-left: 1px solid gray;
 }
+
+/*
+Style differently for printing on paper -- similar to mobile
+Note: So far this seems to work best with Firefox -- Preview as PDF
+*/
+.page-print-break-after {
+	page-break-after: always;
+}
+.page-print-break-before {
+	page-break-before: always;
+}
+.book-page {
+	page-break-after: always;
+}
+@media print {
+	.text-content, .coloring-content {
+		width: 100%;
+		border: none;
+	}
+	nav {
+		display: none;
+	}
+	#get-updates-form-container {
+		display: none;
+	}
+	footer {
+		display: none;
+	}
+}
+
 
 #get-updates-form-container {
 	text-align: center;


### PR DESCRIPTION
- no more todos visible
- default circular tessellations have no reflection
- page breaks for printing
- instructures in README for exporting to PDF or printing