### PR TITLE
removed onhover page change

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ Files are transpiled and built to `/dist` by gulp and are served by a node http-
 
 Can add parameter to URL to avoid page switch on hover of 'Preview Page' or 'Next Page'
 
-- Add `?develop` as URL parameter
-
 
 #### Linting
 

--- a/src/app/book/book.controllers.js
+++ b/src/app/book/book.controllers.js
@@ -180,38 +180,8 @@ function BookCntl($scope, $location, $anchorScroll, $timeout) {
 	};
 
 
-	// Since page changes are triggered on mouse-over action,
-	// only allow page changes from hover to happen in intervals
-	vm.pageChangeReady = true;
-
-	vm.triggerChangePageStart = function() {
-		if (vm.changePageTimeout)
-			$timeout.cancel(vm.changePageTimeout);
-
-		vm.pageChangeReady = false;
-		vm.changePageTimeout = $timeout(function() {
-			vm.pageChangeReady = true;
-		}, 3000);
-	};
-
-	vm.onHoverPreviousPage = function() {
-		if (!vm.pageChangeReady || $location.search().develop)
-			return;
-
-		vm.previousPage();
-	};
-
-	vm.onHoverNextPage = function() {
-		if (!vm.pageChangeReady || $location.search().develop)
-			return;
-
-		vm.nextPage();
-	};
-
 	// change to the previous page
 	vm.previousPage = function() {
-		vm.triggerChangePageStart();
-
 		vm.animateNextPage = false;
 		vm.animatePreviousPage = true;
 		vm.changePage(vm.pageNumber - 1);
@@ -219,8 +189,6 @@ function BookCntl($scope, $location, $anchorScroll, $timeout) {
 
 	// change to the next page
 	vm.nextPage = function() {
-		vm.triggerChangePageStart();
-
 		vm.animateNextPage = true;
 		vm.animatePreviousPage = false;
 		vm.changePage(vm.pageNumber + 1);

--- a/src/app/book/book.css
+++ b/src/app/book/book.css
@@ -128,7 +128,8 @@ move from one book-page to the next with animation:
     text-align: center;
     color: rgb(59,204,166);
     padding: 15px;
-    margin: 15px 0;
+    margin: 15px auto;
+    max-width: 60%;
 }
 .page-change-btn.page-previous-btn {
     margin-top: 12px;

--- a/src/app/book/book.html
+++ b/src/app/book/book.html
@@ -4,12 +4,12 @@
     <div class="page-switch-container">
         <div ng-repeat="p in book.pages">
 
-            <span ng-if="book.page.name == p.name && !main.print" class="page-change-btn page-previous-btn" ng-show="book.showPreviousPageBtn" ng-mouseup="book.previousPage()" ng-mouseover="book.onHoverPreviousPage()"> &#x25B5; Previous Page &#x25B5;</span>
+            <span ng-if="book.page.name == p.name && !main.print" class="page-change-btn page-previous-btn" ng-show="book.showPreviousPageBtn" ng-mouseup="book.previousPage()"> &#x25B5; Previous Page &#x25B5;</span>
 
             <!-- animate page transition based on whether transitioning forward or back in pages -->
             <ng-include ng-class="{'animate-next-page': book.animateNextPage, 'animate-previous-page': book.animatePreviousPage}" src="p.url"></ng-include>
 
-            <span ng-if="book.page.name == p.name && !main.print" class="page-change-btn page-next-btn" ng-show="book.showNextPageBtn" ng-mouseup="book.nextPage()" ng-mouseover="book.onHoverNextPage()">&#x25BD; Next Page &#x25BD;</span>
+            <span ng-if="book.page.name == p.name && !main.print" class="page-change-btn page-next-btn" ng-show="book.showNextPageBtn" ng-mouseup="book.nextPage()">&#x25BD; Next Page &#x25BD;</span>
 
         </div>
     </div>


### PR DESCRIPTION
Reason: sometimes animation was not shown -- page jumped
- Since users didn't realize they had triggered that action by a hover event, they were suddenly sent to a new page and were confused