### PR TITLE
styling frieze pattern symmetries with CSS instead of javascript

### DIFF
--- a/src/app/book/pages/book-page-cover.html
+++ b/src/app/book/pages/book-page-cover.html
@@ -11,7 +11,6 @@
                     group-name='p2'
                     fundamental-domain-width=55
                     fundamental-domain-height=40
-                    show-symmetry-sets=false
                     pattern-function-options='{"levels": 1, "pathsPerLevel": 2, "allowCurved": true}'
                 ></frieze-pattern>
 
@@ -21,7 +20,6 @@
                     group-name='p1'
                     fundamental-domain-width=60
                     fundamental-domain-height=40
-                    show-symmetry-sets=false
                     pattern-function-options='{"levels": 1, "pathsPerLevel": 2, "allowCurved": false}'
                 ></frieze-pattern>
 
@@ -36,7 +34,6 @@
                     group-name='p1'
                     fundamental-domain-width=60
                     fundamental-domain-height=40
-                    show-symmetry-sets=false
                     pattern-function-options='{"levels": 1, "pathsPerLevel": 2, "allowCurved": true}'
                 ></frieze-pattern>
             </div>

--- a/src/app/frieze/frieze.constants.js
+++ b/src/app/frieze/frieze.constants.js
@@ -1,37 +1,7 @@
 
 const frieze = (function() {
-    "use strict";
+    'use strict';
 
-	/*
-	Define how symmetry set lines should be show with RaphaelJS attributes.
-	*/
-	const SYMMETRY_SET_STYLES = {
-		h1: {
-			'stroke': '#007f70',
-			'stroke-width': 2
-		},
-		v1: {
-			'stroke': '#007f70',
-			'stroke-width': 2
-		},
-		v2: {
-			'stroke': '#007f70',
-			'stroke-width': 2
-		},
-		g: {
-			'stroke': 'purple',
-			'stroke-dasharray': '-',
-			'stroke-width': 2,
-	    },
-	    r1: {
-			'stroke': '#e65c00',
-			'stroke-width': 4,
-	    },
-	    r2: {
-			'stroke': '#e65c00',
-			'stroke-width': 4,
-		}
-	};
 
 	const GROUP_DATA = {
 		'p1': {
@@ -80,7 +50,6 @@ const frieze = (function() {
 		},
 	};
     return {
-        GROUP_DATA: GROUP_DATA,
-        SYMMETRY_SET_STYLES: SYMMETRY_SET_STYLES
+        GROUP_DATA: GROUP_DATA
     };
 }());

--- a/src/app/frieze/frieze.html
+++ b/src/app/frieze/frieze.html
@@ -10,13 +10,16 @@
         </ul>
     </nav>
 
-
-    <div ng-repeat="(groupName, groupData) in friezePage.friezeGroupsData" class="frieze-pattern-container">
+    <!-- Creates a pattern container for each group -->
+    <!-- Allows toggling whether to show symmetry sets via a classname -->
+    <div ng-repeat="(groupName, groupData) in friezePage.friezeGroupsData"
+        class="frieze-pattern-container"
+        ng-class="{'show-symmetry-sets': friezePage.showSymmetrySets}">
         <div ng-if="friezePage.selectedGroupName===groupName">
             
             <div class='title-container' ng-click="friezePage.showGroupDetails()">
                 <h1 class='frieze-pattern-title'>{{ groupName }}</h1>
-                <ul ng-show="friezePage.showGroupDescription". class='pattern-generators-list'>
+                <ul ng-show="friezePage.showGroupDescription" class='pattern-generators-list'>
                     <li ng-repeat="generator in groupData.generators">{{generator}}</li>
                 </ul>
             </div>
@@ -26,7 +29,6 @@
                 group-name='{{groupName}}'
                 fundamental-domain-width=100
                 fundamental-domain-height=80
-                show-symmetry-sets={{friezePage.showSymmetrySets}}
                 pattern-function-options='{"levels": 3, "pathsPerLevel": 2, "allowCurved": true}'
             ></frieze-pattern>
 
@@ -35,7 +37,6 @@
                 group-name='{{groupName}}'
                 fundamental-domain-width=100
                 fundamental-domain-height=80
-                show-symmetry-sets={{friezePage.showSymmetrySets}}
                 pattern-function-options='{"levels": 2, "pathsPerLevel": 2, "allowCurved": true}'
             ></frieze-pattern>
             <frieze-pattern
@@ -43,7 +44,6 @@
                 group-name='{{groupName}}'
                 fundamental-domain-width=100
                 fundamental-domain-height=80
-                show-symmetry-sets={{friezePage.showSymmetrySets}}
                 pattern-function-options='{"levels": 2, "pathsPerLevel": 2, "allowCurved": false}'
             ></frieze-pattern>
 
@@ -52,7 +52,6 @@
                 group-name='{{groupName}}'
                 fundamental-domain-width=100
                 fundamental-domain-height=80
-                show-symmetry-sets={{friezePage.showSymmetrySets}}
                 pattern-function-options='{"levels": 3, "pathsPerLevel": 1, "allowCurved": true}'
             ></frieze-pattern>
             <frieze-pattern
@@ -60,7 +59,6 @@
                 group-name='{{groupName}}'
                 fundamental-domain-width=100
                 fundamental-domain-height=80
-                show-symmetry-sets={{friezePage.showSymmetrySets}}
                 pattern-function-options='{"levels": 3, "pathsPerLevel": 1, "allowCurved": false}'
             ></frieze-pattern>
             
@@ -69,7 +67,6 @@
                 group-name='{{groupName}}'
                 fundamental-domain-width=100
                 fundamental-domain-height=80
-                show-symmetry-sets={{friezePage.showSymmetrySets}}
                 pattern-function-options='{"levels": 1, "pathsPerLevel": 2, "allowCurved": true}'
             ></frieze-pattern>
             
@@ -78,7 +75,6 @@
                 group-name='{{groupName}}'
                 fundamental-domain-width=100
                 fundamental-domain-height=80
-                show-symmetry-sets={{friezePage.showSymmetrySets}}
             ></frieze-pattern>
             
             <frieze-pattern
@@ -86,7 +82,6 @@
                 group-name='{{groupName}}'
                 fundamental-domain-width=100
                 fundamental-domain-height=80
-                show-symmetry-sets={{friezePage.showSymmetrySets}}
             ></frieze-pattern>
 
             <frieze-pattern
@@ -94,7 +89,6 @@
                 group-name='{{groupName}}'
                 fundamental-domain-width=100
                 fundamental-domain-height=80
-                show-symmetry-sets={{friezePage.showSymmetrySets}}
                 pattern-function-options='{"levels": 1, "pathsPerLevel": 2, "allowCurved": false}'
             ></frieze-pattern>
 
@@ -103,7 +97,6 @@
                 group-name='{{groupName}}'
                 fundamental-domain-width=100
                 fundamental-domain-height=80
-                show-symmetry-sets={{friezePage.showSymmetrySets}}
                 pattern-function-options='{"levels": 1, "pathsPerLevel": 1, "allowCurved": true}'
             ></frieze-pattern>
 
@@ -112,7 +105,6 @@
                 group-name='{{groupName}}'
                 fundamental-domain-width=100
                 fundamental-domain-height=80
-                show-symmetry-sets={{friezePage.showSymmetrySets}}
             ></frieze-pattern>
 
         </div>

--- a/src/app/posters/you-may-know.html
+++ b/src/app/posters/you-may-know.html
@@ -50,7 +50,6 @@
 			group-name='p1'
 			fundamental-domain-width=60
 			fundamental-domain-height=70
-			show-symmetry-sets=false
 			pattern-function-options='{"levels": 2, "pathsPerLevel": 2, "allowCurved": true}'
 		></frieze-pattern>
 
@@ -79,7 +78,6 @@
 			group-name='p1'
 			fundamental-domain-width=60
 			fundamental-domain-height=70
-			show-symmetry-sets=false
 			pattern-function-options='{"levels": 2, "pathsPerLevel": 2, "allowCurved": true}'
 		></frieze-pattern>
 

--- a/src/assets/css/pattern.css
+++ b/src/assets/css/pattern.css
@@ -79,9 +79,21 @@ Wallpaper and Frieze Page specific
 	}
 }
 
-.wallpaper-pattern,
-.frieze-pattern {
-	display: block;
+#frieze-page ul.pattern-generators-list {
+    list-style-type: none;
+    list-style: none;
+    padding:0;
+    margin:0;
+}
+
+#frieze-page ul.pattern-generators-list li { 
+    padding-left: 1em; 
+    text-indent: -.7em;
+}
+
+#frieze-page ul.pattern-generators-list li:before {
+    content: "- ";
+    /*TODO: set color here on class by class basis; */
 }
 
 #wallpaper-page simple-drawing {
@@ -100,6 +112,44 @@ Wallpaper and Frieze Page specific
 	opacity: 1;
 }
 
+/*
+Pattern styling (vs just pattern page styling)
+*/
+
 #wallpaper-page .wallpaper-pattern {
 	height: 850px;
+}
+
+.wallpaper-pattern,
+.frieze-pattern {
+	display: block;
+}
+
+/* Style the symmetries of the frieze patterns 
+
+There are different types of symmetries, each with their own class name,
+but all symmetry elements share the 'symmetry' class.
+By default they are not shown, but can be toggled to display.
+*/
+.frieze-pattern path.symmetry {
+	opacity: 0;
+}
+.show-symmetry-sets .frieze-pattern path.symmetry,
+.frieze-pattern:hover path.symmetry {
+	opacity: 0.6;
+}
+
+.frieze-pattern path.horizontal-mirror,
+.frieze-pattern path.vertical-mirror {
+	stroke: #007f70;
+	stroke-width: 2;
+}
+.frieze-pattern path.glide-reflection {
+	stroke-width: 2;
+	stroke: purple;
+	stroke-dasharray: 5;
+}
+.frieze-pattern path.rotation {
+	stroke-width: 4;
+	stroke: #e65c00;
 }

--- a/src/assets/js/util.js
+++ b/src/assets/js/util.js
@@ -4,11 +4,25 @@ Collection of utility functions.
 
 
 const util = (function() {
-    "use strict";
+    'use strict';
 
 
     const SYMMETRY_STROKE_WIDTH = 5;
 
+
+    /*
+    Adds a list of class names to each element in a pathSet.
+    */
+    function addClassNamesToElements(pathSet, classNames) {
+        flattenedList(pathSet).forEach(elt => { 
+            classNames.forEach(cn => {
+                if (!elt.node.className.baseVal)
+                    elt.node.className.baseVal = cn;
+                else
+                    elt.node.className.baseVal += (" " + cn);
+            });
+        });
+    }
 
     /*
     Returns a flattened list of elements.
@@ -30,22 +44,6 @@ const util = (function() {
 
     function isNumeric(n) {
       return !isNaN(parseFloat(n)) && isFinite(n);
-    }
-
-    /**
-     * Shows the symmetrySet upon hover with styles
-     * @param {set} paper.Set to apply properties to
-     * @param {styles} dictionary of styles to show upon hover
-    **/
-    function addSymmetrySetProperties(set, styles={}) {
-        if (!styles['stroke-width'])
-            styles['stroke-width'] = SYMMETRY_STROKE_WIDTH;
-        set.attr(styles);
-
-        // initially hide the symmetry set and show upon hover
-        set.attr({opacity: 0});
-        set.mouseover(function() { set.attr({ opacity: 0.6 }); });
-        set.mouseout(function() { set.attr({ opacity: 0 }); });
     }
 
     /**
@@ -159,14 +157,13 @@ const util = (function() {
 
 
     return {
+        addClassNamesToElements: addClassNamesToElements,
         flattenedList: flattenedList,
         isNumeric: isNumeric,
         
         // Symmetry set drawing
-        addSymmetrySetProperties: addSymmetrySetProperties,
         drawOrder2RotationPointSet: drawOrder2RotationPointSet,
         drawYAxesSet: drawYAxesSet,
         drawXaxis: drawXaxis
-
     };
 }());


### PR DESCRIPTION
- cleaner code
- fewer JS listeners

A following change will apply similar CSS rules to the frieze pattern page descriptions