### PR TITLE
tweaks towards clarity for coloring challenges

### DIFF
--- a/src/app/book/pages/book-page-shapes-cn-15.html
+++ b/src/app/book/pages/book-page-shapes-cn-15.html
@@ -93,18 +93,24 @@
                 </div>
 
                 <br/>
-                <br/>
 
                 <p>Similarly, our C1, C2, and C3 groups are all <a target="_blank" href="/theory-reference#subgroup" class="theory-reference-term">subgroups</a> of our C6 group.</p>
 
-                <p class="challenge">Coloring Challenge: Can you color the C6 shapes to reduce them to C1, C2, or C3 shapes?</p>
+                <br/>
+                
+                <p class="challenge">Coloring Challenge: Can you color the C4 and C6 shapes to reduce them to C1 or C2 shapes?</p>
 
-                <!-- [Line of 3 blank C6 shapes] -->
+                <!-- [Line of blank C4 and C6 shapes] -->
                 <div class="text-content-graphic line">
                     <div class='canvas'
                         canvas-centered-drawing
                         draw-function='drawCyclicShape'
-                        function-options='{"N":6}'
+                        function-options='{"N":4}'
+                    ></div>
+                    <div class='canvas'
+                        canvas-centered-drawing
+                        draw-function='drawCyclicShape'
+                        function-options='{"N":4}'
                     ></div>
                     <div class='canvas'
                         canvas-centered-drawing
@@ -127,14 +133,14 @@
         <div class="content-container-wrapper">
             <div class="content-container">
 
-                <!-- 6 order-6 circular patterns -->
+                <!-- 6 order-6 circular patterns - turned to C4 shapes with inscribed square -->
                 <div class="canvas-row">
                     <div class="canvas sixth"
                         circular-pattern
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
@@ -143,7 +149,7 @@
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
@@ -152,7 +158,7 @@
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
@@ -161,7 +167,7 @@
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
@@ -170,7 +176,7 @@
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
@@ -179,7 +185,7 @@
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
@@ -196,7 +202,6 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div><div class="canvas sixth"
                         circular-pattern
                         with-redraw
@@ -204,7 +209,6 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div><div class="canvas sixth"
                         circular-pattern
                         with-redraw
@@ -212,7 +216,6 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div><div class="canvas sixth"
                         circular-pattern
                         with-redraw
@@ -220,7 +223,6 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div><div class="canvas sixth"
                         circular-pattern
                         with-redraw
@@ -228,7 +230,6 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div><div class="canvas sixth"
                         circular-pattern
                         with-redraw
@@ -236,7 +237,6 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div>
                 </div>
 
@@ -247,7 +247,7 @@
                         with-redraw
                         rotations=6
                         slices-count=2
-                        levels=2
+                        levels=1
                         mirror-lines=6
                     ></div><div class="canvas third"
                         circular-pattern
@@ -255,14 +255,14 @@
                         rings="[0.3,0.75,0.8,0.9]"
                         rotations=6
                         slices-count=2
-                        levels=3
+                        levels=2
                         mirror-lines=6
                     ></div><div class="canvas third"
                         circular-pattern
                         with-redraw
                         rotations=6
                         slices-count=2
-                        levels=2
+                        levels=1
                         mirror-lines=6
                     ></div>
                 </div>
@@ -277,7 +277,6 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div><div class="canvas sixth"
                         circular-pattern
                         with-redraw
@@ -285,7 +284,6 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div><div class="canvas sixth"
                         circular-pattern
                         with-redraw
@@ -293,7 +291,6 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div><div class="canvas sixth"
                         circular-pattern
                         with-redraw
@@ -301,7 +298,6 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div><div class="canvas sixth"
                         circular-pattern
                         with-redraw
@@ -309,7 +305,6 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div><div class="canvas sixth"
                         circular-pattern
                         with-redraw
@@ -317,18 +312,17 @@
                         rotations=6
                         slices-count=2
                         levels=2
-                        mirror-lines=1
                     ></div>
                 </div>
 
-                <!-- 6 order-6 circular patterns -->
+                <!-- 6 order-6 circular patterns - turned to C4 shapes with inscribed square -->
                 <div class="canvas-row">
                     <div class="canvas sixth"
                         circular-pattern
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
@@ -337,7 +331,7 @@
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
@@ -346,7 +340,7 @@
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
@@ -355,7 +349,7 @@
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
@@ -364,7 +358,7 @@
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
@@ -373,14 +367,14 @@
                         with-redraw
                         rings="[0.8,0.9]"
                         rotations=6
-                        slices-count=2
+                        slices-count=1
                         levels=2
                         mirror-lines=2
                         inscribed="square"
                     ></div>
                 </div>
             </div>
-            <p class="design-caption">C2, C4, C6 shapes</p>
+            <p class="design-caption">C4 and C6 shapes</p>
         </div>
     </div>
 </div>

--- a/src/app/book/pages/book-page-shapes-cn-18.html
+++ b/src/app/book/pages/book-page-shapes-cn-18.html
@@ -92,12 +92,8 @@
                 <br/>
                 <br/>
                 <br/>
-                <br/>
-                <br/>
-                <br/>
-                <br/>
 
-                <p class="challenge">Coloring Challenge: Color the shapes to make them all C2 shapes.</p>
+                <p class="challenge">Coloring Challenge: Color the C4 shapes to make them all C2 shapes.</p>
             </div>
         </div>
     </div>
@@ -105,7 +101,6 @@
     <div class="coloring-content">
         <div class="content-container-wrapper">
             <div class="content-container">
-
                 <div class="canvas-row">
                     <div class='canvas sixth'
                         canvas-centered-drawing
@@ -188,6 +183,8 @@
                     ></div>
                 </div>
             </div>
+            <p class="design-caption">C4 shapes</p>
         </div>
     </div>
+    <!-- coloring-content -->
 </div>

--- a/src/app/book/pages/book-page-shapes-dn-7.html
+++ b/src/app/book/pages/book-page-shapes-dn-7.html
@@ -114,7 +114,7 @@
                 <br/>
                 <br/>
 
-                <p class="challenge">Challenge: Which dihedral group does each uncolored shape belong to?</p>
+                <p class="challenge">Challenge: Which dihedral group does each illustrated shape belong to?</p>
             </div>
 	    </div>
     </div>
@@ -421,5 +421,4 @@
         </div>
     </div>
     <!-- coloring-content -->
-
 </div>

--- a/src/app/book/pages/book-page-shapes-dn-8.html
+++ b/src/app/book/pages/book-page-shapes-dn-8.html
@@ -181,10 +181,8 @@
                         options='{"tapReflect": "V", "margin":0, "initialRotation":180}'
                     ></div>
                 </div>
-
             </div>
         </div>
     </div>
     <!-- coloring-content -->
-
 </div>


### PR DESCRIPTION
lindsey (via RC Zulip) pointed out how confused she was about what was a 'challenge' or a 'coloring challenge'.  A bigger audit with fixes is needed to resolve this ambiguity.  Small tweaks are address in this commit.

The inconsistency in which shapes correspond to the coloring challenges is confusing
“I was a bit confused by some of the challenge problems. On this page, for instance, the problem is "Challenge: Which dihedral group does each uncolored shape belong to?", and I didn't know if that was referring to the shapes above or on the right or what. Is there a missing illustration below? If it's supposed to be referring to the shapes on the right, then the problem seems too easy, since they're already arranged into rows by group.
You’re right that the shapes are already lined up in rows by groups and that this is easy once you see that.  I thought some people might not immediately see that and wanted this as a checkpoint.  You are so right that this is unclear!  You also helped me realize that the word “uncolored” only adds confusion.  I replaced it with “illustrated” in the hope that would guide people to the “illustrations” on the right.  I wonder if this helps at all

For some of the other challenges, like on this page, the challenge is about the shapes on the right. Actually, I just realized that maybe that's what "Coloring Challenge" means, as opposed to just "Challenge". Maybe this could be explained up front.
As a tweak towards clarity I updated this to read “Coloring Challenge: Color the C4 shapes to make them all C2 shapes.” and put the caption of “C4 shapes” below the illustrations on the right.

But then, this page has a "Coloring Challenge" but also has shapes below. I'm not sure if the challenge is supposed to be about those, or about the ones on the right.
With all these ambiguities, I started to wish that the book had hidden solutions to the challenge problems that could be revealed by clicking. That might be a lot of effort to add, but I bet people would be interested in trying to check their work.
I really do wish I had created a solution sheet of some sort, I think that will be the next iteration of this project!

For example, on this page, it's called a "coloring challenge", but it seems to only have to do with the content directly below it, not the content on the right.
I don't think I have a great idea for resolving the confusion everywhere, but one thing that might help would be to audit where you're saying things like "the triangles" or "the shapes" in the challenges, and instead say, e.g., "the three triangles below" or "the sixteen shapes on the right", to make it obvious what you're talking about.
Also, I'm still not sure if a "coloring challenge" is meant to be a distinct thing from a "challenge".
Thanks again for pointing this out.  I made another tweak with the intention of more clarity for this page: http://www.coloring-book.co/?pageName=cn-15&pageNumber=21
The coloring challenge was intended for both the below shapes as well as the shapes on the right.
Now the coloring challenge is about C4 and C6 shapes, and is only C4 and C6 shapes directly below and to the right, with the caption on the right indicating so.