### PR TITLE
no more white fill for circular patterns

### DIFF
--- a/src/app/common/directives/circular-pattern.js
+++ b/src/app/common/directives/circular-pattern.js
@@ -111,10 +111,6 @@ function circularPatternDirective($location) {
 				drawRings(rings);
 
 				scope.circularPattern = new CircularPattern(paper, origin, diameter, options);
-				// If there are rings, then fill the path so that it sits above the rings
-				// Unless this shape has reflection!  Because they it will cover its own reflections.
-				if (!scope.withReflection && !asFlower && rings && rings.length)
-					scope.circularPattern.pathSet.attr("fill", "white");
 
 				// draw mirror lines last so that they sit on top
 				if (scope.mirrorLines)


### PR DESCRIPTION
reason: addresses visual bug where sometimes patterns not perfectly symmetric because of how pieces draw over each other